### PR TITLE
Use three dots for ellipsis for "More" item

### DIFF
--- a/qml/tweetian-harmattan/MainPageCom/TweetListView.qml
+++ b/qml/tweetian-harmattan/MainPageCom/TweetListView.qml
@@ -123,7 +123,7 @@ Item {
 
         PullDownMenu {
             MenuItem {
-                text: qsTr("More..")
+                text: qsTr("More...")
                 onClicked: pageStack.push(Qt.resolvedUrl("../MorePage.qml"))
             }
 


### PR DESCRIPTION
For aesthetic reasons, use three dots as in other labels throughout the
application.
