### PR TITLE
Polish application startup

### DIFF
--- a/qml/tweetian-harmattan/MainPageCom/DirectMessage.qml
+++ b/qml/tweetian-harmattan/MainPageCom/DirectMessage.qml
@@ -116,7 +116,7 @@ Item {
 
     }
 
-    ScrollDecorator { flickable: directMsgView }
+    VerticalScrollDecorator { flickable: directMsgView }
 
     Text {
         anchors.centerIn: parent

--- a/qml/tweetian-harmattan/MainPageCom/TweetListView.qml
+++ b/qml/tweetian-harmattan/MainPageCom/TweetListView.qml
@@ -175,7 +175,7 @@ Item {
         }
     }
 
-    ScrollDecorator { flickable: tweetView }
+    VerticalScrollDecorator { flickable: tweetView }
 
    // FastScroll { listView: tweetView }
 

--- a/qml/tweetian-harmattan/SignInPage.qml
+++ b/qml/tweetian-harmattan/SignInPage.qml
@@ -35,7 +35,7 @@ Page {
 
     SilicaFlickable {
         id: flickable
-        anchors { top: header.bottom; left: parent.left; right: parent.right; bottom: parent.bottom }
+        anchors.fill: parent
         contentHeight: mainColumn.height + 2 * mainColumn.anchors.topMargin
 
         Column {
@@ -47,6 +47,12 @@ Page {
                 rightMargin: Theme.paddingLarge
             }
             spacing: constant.paddingMedium
+
+            PageHeader {
+                id: header
+                title: qsTr("Sign In to Twitter")
+                property bool busy: false
+            }
 
             Text {
                 anchors { left: parent.left; right: parent.right }
@@ -115,14 +121,8 @@ below and click done.")
                 onClicked: internal.doneButtonClicked()
             }
         }
-    }
 
-    ScrollDecorator { flickable: flickable }
-
-    PageHeader {
-        id: header
-        title: qsTr("Sign In to Twitter")
-        property bool busy: false
+        ScrollDecorator { flickable: flickable }
     }
 
     QtObject {

--- a/qml/tweetian-harmattan/SignInPage.qml
+++ b/qml/tweetian-harmattan/SignInPage.qml
@@ -90,35 +90,22 @@ Click the button below will launch an external web browser for you to sign in to
 below and click done.")
             }
 
-            Item {
-                id: pinCodeTextFieldWrapper
-                anchors { left: parent.left; right: parent.right }
-                height: pinCodeTextFieldRow.height + 2 * constant.paddingXLarge
-
-                Row {
-                    id: pinCodeTextFieldRow
-                    anchors.centerIn: parent
-                    width: childrenRect.width; height: pinCodeTextField.height
-                    spacing: constant.paddingLarge
-
-                    Text {
-                        anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: constant.fontSizeMedium
-                        color: constant.colorLight
-                        text: "PIN:"
-                    }
-
-                    TextField {
-                        id: pinCodeTextField
-                        width: pinCodeTextFieldWrapper.width * 0.7
-                        enabled: !header.busy
-                        inputMethodHints: Qt.ImhDigitsOnly
-
-                        EnterKey.enabled: text.length > 0
-                        EnterKey.iconSource: "image://theme/icon-m-enter-accept"
-                        EnterKey.onClicked: internal.doneButtonClicked()
-                    }
+            TextField {
+                id: pinCodeTextField
+                anchors {
+                    left: parent.left; right: parent.right
+                    // TextField has implicit large paddings
+                    leftMargin: -Theme.paddingLarge
+                    rightMargin: -Theme.paddingLarge
                 }
+
+                enabled: !header.busy
+                inputMethodHints: Qt.ImhDigitsOnly
+                placeholderText: "Enter PIN code"
+                label: "PIN"
+                EnterKey.enabled: text.length > 0
+                EnterKey.iconSource: "image://theme/icon-m-enter-accept"
+                EnterKey.onClicked: internal.doneButtonClicked()
             }
 
             Button {

--- a/qml/tweetian-harmattan/SignInPage.qml
+++ b/qml/tweetian-harmattan/SignInPage.qml
@@ -40,8 +40,12 @@ Page {
 
         Column {
             id: mainColumn
-            anchors { left: parent.left; right: parent.right; top: parent.top; topMargin: constant.paddingMedium }
-            height: childrenRect.height
+            anchors {
+                left: parent.left; right: parent.right; top: parent.top
+                topMargin: constant.paddingMedium
+                leftMargin: Theme.paddingLarge
+                rightMargin: Theme.paddingLarge
+            }
             spacing: constant.paddingMedium
 
             Text {

--- a/qml/tweetian-harmattan/SignInPage.qml
+++ b/qml/tweetian-harmattan/SignInPage.qml
@@ -122,7 +122,7 @@ below and click done.")
             }
         }
 
-        ScrollDecorator { flickable: flickable }
+        VerticalScrollDecorator { flickable: flickable }
     }
 
     QtObject {


### PR DESCRIPTION
- Use large paddings for SignInPage
- Use TextField's label instead of extra Text item
- PageHeader moved inside Flickable at SignInPage. PageHeader should be inside flickable so that in moves along with the content
- Binding loops fixed at the startup
