### PR TITLE
Link style changed

### DIFF
--- a/qml/tweetian-harmattan/Utils/Parser.js
+++ b/qml/tweetian-harmattan/Utils/Parser.js
@@ -22,7 +22,7 @@ Qt.include("Calculations.js")
 
 function linkText(text, href, italic) {
     var html = "";
-    if (italic) html = "<i><a style=\"color: white; text-decoration: none\" href=\"%1\">%2</a></i>";
+    if (italic) html = "<a style=\"color: LightGray; text-decoration: underline\" href=\"%1\">%2</a>";
     else html = "<a style=\"color: DarkGray; text-decoration: none\" href=\"%1\">%2</a>";
 
     return html.arg(href).arg(text);


### PR DESCRIPTION
Removed italic and added underline to URL links. and changed color of URL
link slightly. I also tried to change link URL and #/@ link colors to theme colors, but I failed at importing silica theme. As soon as I try something like:

.pragma library
.import Sailfish.Silica.Theme 1.0 as SilicaTheme

Qt.include("Calculations.js")

function linkText(text, href, italic) {
    var html = "";
    var color_link = SilicaTheme.primaryColor;
    if (italic) html = "<a style=\"color: "+color_link+"; text-decoration: underline\" href=\"%1\">%2</a>";
    else html = "<a style=\"color: DarkGray; text-decoration: none\" href=\"%1\">%2</a>";

```
return html.arg(href).arg(text);
```

}

I get an non functioning parsing with this error: 
[W] unknown:133 - qrc:/qml/tweetian-harmattan/WorkerScript/TweetsParser.js:133: ReferenceError: parseTweet is not defined

Maybe someone else with more coding skills can do a follow up.
