### PR TITLE
Block user, and update Flickr URLs

### DIFF
--- a/qml/tweetian-harmattan/TweetPageJS.js
+++ b/qml/tweetian-harmattan/TweetPageJS.js
@@ -139,6 +139,20 @@ var PIC_SERVICES = [
         }
     },
     {
+        regexp: /http:\/\/www\.wikipaintings\.org\/..\/(?!tag)(?!search)[\w-]+\/[\w-]+/ig,
+        getPicUrl: function(link) {
+            link = link.replace(/#.*$/,'') // strip any anchor
+            link = link.replace('http://www.', 'http://uploads.')
+            link = link.replace(/\.org\/..\//, '.org/images/')
+            link = link + ".jpg"
+            var url = {
+                full: link,
+                thumb: link + "!BlogSmall.jpg"
+            }
+            return url
+        }
+    },
+    {
         regexp: /https?:\/\/[^"]+?\.(?:jpe?g|png|gif)(?=")/gi,
         getPicUrl: function (link) { return { full: link, thumb: link }; }
     }

--- a/qml/tweetian-harmattan/UserPage.qml
+++ b/qml/tweetian-harmattan/UserPage.qml
@@ -81,7 +81,7 @@ Page {
             MenuItem {
                 text: qsTr("Block user")
                 enabled: screenName !== settings.userScreenName
-                onClicked: internal.createReportSpamDialog()
+                onClicked: internal.createBlockUserDialog();
             }
             MenuItem {
                 text: qsTr("Report user as spammer")

--- a/qml/tweetian-symbian/TweetPageJS.js
+++ b/qml/tweetian-symbian/TweetPageJS.js
@@ -139,6 +139,20 @@ var PIC_SERVICES = [
         }
     },
     {
+        regexp: /http:\/\/www\.wikipaintings\.org\/..\/(?!tag)(?!search)[\w-]+\/[\w-]+/ig,
+        getPicUrl: function(link) {
+            link = link.replace(/#.*$/,'') // strip any anchor
+            link = link.replace('http://www.', 'http://uploads.')
+            link = link.replace(/\.org\/..\//, '.org/images/')
+            link = link + ".jpg"
+            var url = {
+                full: link,
+                thumb: link + "!BlogSmall.jpg"
+            }
+            return url
+        }
+    },
+    {
         regexp: /https?:\/\/[^"]+?\.(?:jpe?g|png|gif)(?=")/gi,
         getPicUrl: function (link) { return { full: link, thumb: link }; }
     }


### PR DESCRIPTION
Two things:
- Add an option to block a user without reporting as spam. See also: https://github.com/dicksonleong/Tweetian/pull/25
- Support both http and https Flickr URLs. See also: https://github.com/dicksonleong/Tweetian/pull/26
