### PR TITLE
Added InfoBanner msg when opening links in external browser

### DIFF
--- a/qml/tweetian-harmattan/SignInPage.qml
+++ b/qml/tweetian-harmattan/SignInPage.qml
@@ -134,7 +134,7 @@ below and click done.")
                 tokenSecretTempo = tokenSecret;
                 var signInUrl = "https://api.twitter.com/oauth/authorize?oauth_token=" + tokenTempo;
                 Qt.openUrlExternally(signInUrl);
-                infoBanner.showText("Launching external web browser...");
+                infoBanner.showText(qsTr("Launching external web browser..."));
                 header.busy = false;
                 console.log("Launching web browser with url:", signInUrl);
              }, function(status, statusText) {

--- a/qml/tweetian-harmattan/main.qml
+++ b/qml/tweetian-harmattan/main.qml
@@ -126,6 +126,7 @@ ApplicationWindow {
                 dialog.addToPocketClicked.connect(pocketCallback)
                 dialog.addToInstapaperClicked.connect(instapaperCallback)
             }*/
+            infoBanner.showText(qsTr("Launching external web browser..."))
             Qt.openUrlExternally(link)
         }
 


### PR DESCRIPTION
There was attempt to fix this in 522729f5084758a9a3f03da5f997c88bb0a6e13c but the OpenLinkDialog is not in use since f5bd6cb8dd18ad3c5c1094ccc67e66973c5674be so it doesn't really show the infoBanner when clicking URL links. There is also the haptic feedback for all types of links, but at least on the latest OS version QtFeedback API usually fails to work: "[W] QFeedbackFFMemless::uploadEffect:361 - bool QFeedbackFFMemless::uploadEffect(ff_effect*) Unable to upload effect".
