### PR TITLE
Display images embedded into DMs

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -50,8 +50,8 @@ public:
     {
         const QString authToken = QUrl::fromPercentEncoding(id.toLatin1());
 
-        // We expect a fixed format of the token: real containing URL of the
-        // image is in the real parameter which comes first in the list.
+        // We expect a fixed format of the token: URL of the requested image is
+        // in the realm parameter which comes first.
         QRegExp realmRe("^OAuth realm=\"([^\"]+)\"");
         if (realmRe.indexIn(authToken) != 0) {
             return QImage();

--- a/qml/tweetian-harmattan/Delegate/DirectMsgDelegate.qml
+++ b/qml/tweetian-harmattan/Delegate/DirectMsgDelegate.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.1
 import Sailfish.Silica 1.0
 import "../Services/Twitter.js" as Twitter
+import "../Component"
 
 AbstractDelegate {
     id: root
@@ -77,6 +78,46 @@ AbstractDelegate {
         color: highlighted ? constant.colorHighlighted : constant.colorMid
         elide: Text.ElideRight
         text: timeDiff
+    }
+
+
+    ThumbnailItem {
+        function hasMedia() {
+            return (typeof model.mediaUrl !== "undefined") &&
+                   (model.mediaUrl.indexOf("http") === 0);
+        }
+
+        function getImageProviderUrl() {
+            return "image://dm/" + encodeURIComponent(Twitter.getTwitterImageDownloadAuthHeader(model.mediaUrl));
+        }
+
+        visible: {
+            return hasMedia()
+        }
+
+        width: {
+            return hasMedia() ? constant.thumbnailSize : 0
+        }
+
+        height: {
+            return hasMedia() ? constant.thumbnailSize : 0
+        }
+
+        imageSource: {
+            return hasMedia() ? getImageProviderUrl() : "";
+        }
+
+        iconSource: {
+            return settings.invertedTheme ? "../Image/photos_inverse.svg"
+                                          : "../Image/photos.svg"
+        }
+
+        onClicked: {
+            pageStack.push(Qt.resolvedUrl("../TweetImage.qml"), {
+                imageLink: model.mediaUrl,
+                imageUrl: getImageProviderUrl()
+            })
+        }
     }
 
     onPressAndHold: if(!model.isReceiveDM) contextMenu.show(root)

--- a/qml/tweetian-harmattan/Services/Twitter.js
+++ b/qml/tweetian-harmattan/Services/Twitter.js
@@ -541,3 +541,18 @@ function getOAuthEchoAuthHeader() {
     OAuth.completeRequest(message, accessor)
     return OAuth.getAuthorizationHeader(message.action, message.parameters)
 }
+
+function getTwitterImageDownloadAuthHeader(url) {
+    var accessor = {
+        consumerKey: OAUTH_CONSUMER_KEY,
+        consumerSecret: OAUTH_CONSUMER_SECRET,
+        token: OAUTH_TOKEN,
+        tokenSecret: OAUTH_TOKEN_SECRET
+    }
+    var message = {
+        action: url,
+        method: "GET"
+    }
+    OAuth.completeRequest(message, accessor)
+    return OAuth.getAuthorizationHeader(message.action, message.parameters)
+}

--- a/qml/tweetian-harmattan/Utils/Parser.js
+++ b/qml/tweetian-harmattan/Utils/Parser.js
@@ -81,6 +81,12 @@ function parseDM(dmJson, isReceiveDM) {
         createdAt: twitterDateToISOString(dmJson.created_at),
         isReceiveDM: isReceiveDM
     }
+    if (Array.isArray(dmJson.entities.media) && dmJson.entities.media.length > 0) {
+        dm.mediaUrl = dmJson.entities.media[0].media_url;
+    } else {
+        dm.mediaUrl = "";
+    }
+
     return dm;
 }
 

--- a/qml/tweetian-harmattan/WorkerScript/DMConversationParser.js
+++ b/qml/tweetian-harmattan/WorkerScript/DMConversationParser.js
@@ -35,7 +35,8 @@ WorkerScript.onMessage = function(msg) {
                 screenName: dm.screenName,
                 profileImageUrl: dm.profileImageUrl,
                 createdAt: dm.createdAt,
-                isReceiveDM: dm.isReceiveDM
+                isReceiveDM: dm.isReceiveDM,
+                mediaUrl: dm.mediaUrl
             }
             toBeInsertDM.timeDiff = timeDiff(dm.createdAt)
             msg.model.insert(count, toBeInsertDM)

--- a/tweetian.pro
+++ b/tweetian.pro
@@ -96,6 +96,7 @@ OTHER_FILES += qtc_packaging/debian_harmattan/* \
     qml/tweetian-harmattan/Services/*.js
 
 CONFIG += link_pkgconfig
+CONFIG += c++11
 packagesExist(sailfishapp) {
 message("sailfishapp")
     PKGCONFIG += sailfishapp mlite5


### PR DESCRIPTION
Accessing images embedded into DMs requires proper OAuth token.

There is no way to tweak headers for an image request from QML - so we instead implement an image provider (subclass of `QQuickImageProvider`) that can pass custom headers alongside the request it sends.

Implemented image provider captures all `http://dm/<auth-token>` requests and then requests images passing the given auth-token as `Authorization` header. Image URL itself is extracted from the `realm` parameter of the auth token.

The rest of the changes are simple plumbing passing media url from API into the database and into the model.
